### PR TITLE
Exception for user-agent error

### DIFF
--- a/src/u2flib_server/U2F.php
+++ b/src/u2flib_server/U2F.php
@@ -56,6 +56,9 @@ const ERR_COUNTER_TOO_LOW = 8;
 /** Error decoding public key */
 const ERR_PUBKEY_DECODE = 9;
 
+/** Error user-agent returned error */
+const ERR_BAD_UA_RETURNING = 10;
+
 /** @internal */
 const PUBKEY_LEN = 65;
 
@@ -109,6 +112,10 @@ class U2F {
 
     if( !is_object( $response ) ) {
     	throw new \InvalidArgumentException('$response of doRegister() method only accepts object.');
+    }
+
+    if( property_exists( $response, 'errorCode') ) {
+    	throw new Error('User-agent returned error. Error code: ' . $response->errorCode, ERR_BAD_UA_RETURNING );
     }
 
     if( !is_bool( $include_cert ) ) {
@@ -226,6 +233,10 @@ class U2F {
 
     if( !is_object( $response ) ) {
     	throw new \InvalidArgumentException('$response of doAuthenticate() method only accepts object.');
+    }
+
+    if( property_exists( $response, 'errorCode') ) {
+    	throw new Error('User-agent returned error. Error code: ' . $response->errorCode, ERR_BAD_UA_RETURNING );
     }
 
     $req = null;

--- a/tests/u2flib_test.php
+++ b/tests/u2flib_test.php
@@ -155,6 +155,16 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
+   * @expectedException u2flib_server\Error
+   * @expectedExceptionCode u2flib_server\ERR_BAD_UA_RETURNING
+   */
+  public function testDoRegisterUAError() {
+    $req = json_decode('{"version":"U2F_V2","challenge":"yKA0x075tjJ-GE7fKTfnzTOSaNUOWQxRd9TWz5aFOg8","appId":"http://demo.example.com"}');
+    $resp = json_decode('{"errorCode": "4"}');
+    $reg = $this->u2f->doRegister($req, $resp);
+  }
+
+  /**
    * @expectedException \InvalidArgumentException
    * @expectedExceptionMessage $include_cert of doRegister() method only accepts boolean.
    */
@@ -310,6 +320,16 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
     $data = $this->u2f->doAuthenticate($reqs, $regs, $resp);
   }
 
+  /**
+   * @expectedException u2flib_server\Error
+   * @expectedExceptionCode u2flib_server\ERR_BAD_UA_RETURNING
+   */
+  public function testDoAuthenticateUAError() {
+    $reqs = array(json_decode('{"version":"U2F_V2","challenge":"fEnc9oV79EaBgK5BoNERU5gPKM2XGYWrz4fUjgc0Q7g","keyHandle":"CTUayZo8hCBeC-sGQJChC0wW-bBg99bmOlGCgw8XGq4dLsxO3yWh9mRYArZxocP5hBB1pEGB3bbJYiM-5acc5w","appId":"http://demo.example.com"}'));
+    $regs = array(json_decode('{"keyHandle":"CTUayZo8hCBeC-sGQJChC0wW-bBg99bmOlGCgw8XGq4dLsxO3yWh9mRYArZxocP5hBB1pEGB3bbJYiM-5acc5w","publicKey":"BC0SaFZWC9uH7wamOwduP93kUH2I2hEvyY0Srfj4A258pZSlV0iPoFIH+bd4yhncaqdoPLdEDl5Y\/yaFORPUe3c=","certificate":"MIIC4jCBywIBATANBgkqhkiG9w0BAQsFADAdMRswGQYDVQQDExJZdWJpY28gVTJGIFRlc3QgQ0EwHhcNMTQwNTE1MTI1ODU0WhcNMTQwNjE0MTI1ODU0WjAdMRswGQYDVQQDExJZdWJpY28gVTJGIFRlc3QgRUUwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATbCtv1IcdczmPcpuHoJQYNlOYnVBlPnSSvJhq+rZlEH5WjcZEKOiDnPpFeE+i+OAV61XqjfnaQj6\/iipS2MOudMA0GCSqGSIb3DQEBCwUAA4ICAQCVQGtQYX2thKO064gP4zAPLaIKANklBO5y+mffWFEPC0cCnD5BKUqTrCmFiS2keoEyKFdxAe+oQogWljeR1d\/gj8k8jbDNiXCC7HnTxnhzKTLlq2y9Vp\/VRZHOwd2NZNzpnB9ePNKvUaWCGK\/gN+cynnYFdwJ75iSgMVYb\/RnFcdPwnsBzBU68hbhTnu\/FvJxWo7rZJ2q7qXpA10eLVXJr4\/4oSXEk9I\/0IIHqOP98Ck\/fAoI5gYI7ygndyqoPJ\/Wkg1VsmjmbFToWY9xb+axbvPefvg+KojwxE6MySMpYh\/h7oKEKamCWk19dJp5jHQmumkHlvQhH\/uUJmyD9EuLmQH+6SmEzZg0Oc9uw1aKamhcNNDCFakJGnv80j1+HbDXnqE0168FBqorS2hmqeaJfNSyg\/SXT950lGC36tLy7BzQ8jYG99Ok32znp0UVbIEEvLSci3JJ0ipLVg\/0J+xOb4zl6a1z65nae4OTj7628\/UJFmtSU0X6Np9gF1dNizxXPlH0fW1ggRCCQcb5m6ZqrdDJwUx1p7Ydm9AlPyiUwwmN5ADyxmzk\/AOCoiO96UVvnvUlk2kF7JMNxIv3R0SCzP5fTl7KqGByeA3d7W375o6DWIIEsOI+dJd7pyPXdakecZQRaVubC6\/ICl+G52OEkdp8jYjkDS8j3NAdJ1udNmg==", "counter":3}'));
+    $resp = json_decode('{"errorCode": "5"}');
+    $data = $this->u2f->doAuthenticate($reqs, $regs, $resp);
+  }
 }
 
 ?>


### PR DESCRIPTION
With this exception, developers can:
 * use `try-catch-finally` to handle errors returned by user-agent.
 * lessen the amount of JavaScript if they wants to do so.