### PR TITLE
Prevent unwanted output to the browser

### DIFF
--- a/src/u2flib_server/U2F.php
+++ b/src/u2flib_server/U2F.php
@@ -402,5 +402,3 @@ class Error extends \Exception {
     parent::__construct($message, $code, $previous);
   }
 }
-
-?>


### PR DESCRIPTION
I removed the trailing `?>` and new line that could lead to unwanted output. The end `?>` is unnecessary and discouraged (see: http://framework.zend.com/manual/1.12/en/coding-standard.php-file-formatting.html#coding-standard.php-file-formatting.general).