### PR TITLE
Add Build Status and Coverage badges

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
-php-u2flib-server
------------------
+php-u2flib-server image:https://travis-ci.org/Yubico/php-u2flib-server.svg?branch=master["Build Status", link="https://travis-ci.org/Yubico/php-u2flib-server"] image:https://coveralls.io/repos/Yubico/php-u2flib-server/badge.svg?branch=master&service=github["Coverage", link="https://coveralls.io/github/Yubico/php-u2flib-server?branch=master"]
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Serverside U2F library for PHP. Provides functionality for registering
 tokens and authentication with said tokens.


### PR DESCRIPTION
One of the first things I personally do before using a library is checking it's coverage. A green badge in the readme is at least encouraging me to take a more proper look at it :)

![2015-10-10_00-06-04](https://cloud.githubusercontent.com/assets/878997/10406730/b4b6f0de-6ee2-11e5-9d81-95f9c35574fc.png)
