### PR TITLE
Make PHP 7 check mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - nightly
+  - 7.0
   - hhvm
   - hhvm-nightly
 after_success:
@@ -14,6 +14,5 @@ matrix:
     - php: 5.6
       env: COVERALLS=true
   allow_failures:
-    - php: nightly
     - php: hhvm
     - php: hhvm-nightly


### PR DESCRIPTION
PHP 7.0.0 RC4 has been published and thus it makes sense to make the check mandatory.