### PR TITLE
Use common challenge for multiple registrations

### DIFF
--- a/src/u2flib_server/U2F.php
+++ b/src/u2flib_server/U2F.php
@@ -222,6 +222,7 @@ class U2F
     public function getAuthenticateData(array $registrations)
     {
         $sigs = array();
+        $challenge = $this->createChallenge();
         foreach ($registrations as $reg) {
             if( !is_object( $reg ) ) {
                 throw new \InvalidArgumentException('$registrations of getAuthenticateData() method only accepts array of object.');
@@ -230,7 +231,7 @@ class U2F
             $sig = new SignRequest();
             $sig->appId = $this->appId;
             $sig->keyHandle = $reg->keyHandle;
-            $sig->challenge = $this->createChallenge();
+            $sig->challenge = $challenge;
             $sigs[] = $sig;
         }
         return $sigs;


### PR DESCRIPTION
With U2F API v1.1 the same challenge is used for all registrations, so with this it is easier to use this library with the new API.