### PR TITLE
Additional error checks

### DIFF
--- a/src/u2flib_server/U2F.php
+++ b/src/u2flib_server/U2F.php
@@ -32,6 +32,12 @@ namespace u2flib_server;
 /** Constant for the version of the u2f protocol */
 const U2F_VERSION = "U2F_V2";
 
+/** Constant for the type value in registration clientData */
+const REQUEST_TYPE_REGISTER = "navigator.id.finishEnrollment";
+
+/** Constant for the type value in authentication clientData */
+const REQUEST_TYPE_AUTHENTICATE = "navigator.id.getAssertion";
+
 /** Error for the authentication message not matching any outstanding
  * authentication request */
 const ERR_NO_MATCHING_REQUEST = 1;
@@ -68,6 +74,15 @@ const ERR_BAD_UA_RETURNING = 10;
 
 /** Error old OpenSSL version */
 const ERR_OLD_OPENSSL = 11;
+
+/** Error for the origin not matching the appId */
+const ERR_NO_MATCHING_ORIGIN = 12;
+
+/** Error for the type in clientData being invalid */
+const ERR_BAD_TYPE = 13;
+
+/** Error for bad user presence byte value */
+const ERR_BAD_USER_PRESENCE = 14;
 
 /** @internal */
 const PUBKEY_LEN = 65;
@@ -158,6 +173,14 @@ class U2F
 
         if($cli->challenge !== $request->challenge) {
             throw new Error('Registration challenge does not match', ERR_UNMATCHED_CHALLENGE );
+        }
+
+        if(isset($cli->typ) && $cli->typ !== REQUEST_TYPE_REGISTER) {
+            throw new Error('ClientData type is invalid', ERR_BAD_TYPE);
+        }
+
+        if(isset($cli->origin) && $cli->origin !== $request->appId) {
+            throw new Error('App ID does not match the origin', ERR_NO_MATCHING_ORIGIN);
         }
 
         $registration = new Registration();
@@ -269,6 +292,11 @@ class U2F
 
         $clientData = $this->base64u_decode($response->clientData);
         $decodedClient = json_decode($clientData);
+
+        if(isset($decodedClient->typ) && $decodedClient->typ !== REQUEST_TYPE_AUTHENTICATE) {
+            throw new Error('ClientData type is invalid', ERR_BAD_TYPE);
+        }
+
         foreach ($requests as $req) {
             if( !is_object( $req ) ) {
                 throw new \InvalidArgumentException('$requests of doAuthenticate() method only accepts array of object.');
@@ -282,6 +310,9 @@ class U2F
         }
         if($req === null) {
             throw new Error('No matching request found', ERR_NO_MATCHING_REQUEST );
+        }
+        if(isset($decodedClient->origin) && $decodedClient->origin !== $req->appId) {
+            throw new Error('App ID does not match the origin', ERR_NO_MATCHING_ORIGIN);
         }
         foreach ($registrations as $reg) {
             if( !is_object( $reg ) ) {

--- a/src/u2flib_server/U2F.php
+++ b/src/u2flib_server/U2F.php
@@ -339,6 +339,10 @@ class U2F
         $signature = substr($signData, 5);
 
         if(openssl_verify($dataToVerify, $signature, $pemKey, 'sha256') === 1) {
+            $upb = unpack("Cupb", substr($signData, 0, 1)); 
+            if($upb['upb'] !== 1) { 
+                throw new Error('User presence byte value is invalid', ERR_BAD_USER_PRESENCE );
+            }
             $ctr = unpack("Nctr", substr($signData, 1, 4));
             $counter = $ctr['ctr'];
             /* TODO: wrap-around should be handled somehow.. */


### PR DESCRIPTION
A couple of years ago, I used this lib to run the conformance tests at http://u2fconformance.fidoalliance.org. To comply with those tests, I had to add a few error checks to the U2F lib so that it doesn't return false positives. If I remember correctly, I took these error checks from the Java implementation and ported them over to PHP. I did this in June 2015, so I might be mis-remembering the source from which I took these changes. I just came back to this repo to check if there were any bug fixes and cleanups, and realized I had never posted this upstream, so here it is.