### PR TITLE
Allow subclasses to override createChallenge + move classes into several files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
     "php": ">=5.6"
   },
   "autoload": {
-    "classmap": ["src/"]
+    "psr-4": {
+      "u2flib_server\\":"src/u2flib_server/"
+    }
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7"

--- a/examples/assets/u2f-api.js
+++ b/examples/assets/u2f-api.js
@@ -271,7 +271,7 @@ u2f.WrappedChromeRuntimePort_.prototype.addEventListener =
 u2f.WrappedAuthenticatorPort_ = function() {
     this.requestId_ = -1;
     this.requestObject_ = null;
-}
+};
 
 /**
  * Launch the Authenticator intent.

--- a/examples/cli/u2f-server.phps
+++ b/examples/cli/u2f-server.phps
@@ -31,10 +31,10 @@
 
 /**
  * This is a basic example of a u2f-server command line that can be used 
- * with the u2f-host binary to perform regitrations and authentications.
- */ 
+ * with the u2f-host binary to perform registrations and authentications.
+ */
 
-require_once('../../src/u2flib_server/U2F.php');
+require_once __DIR__ . '/../../vendor/autoload.php';
 
 $options = getopt("rao:R:");
 $mode;

--- a/examples/localstorage/index.phps
+++ b/examples/localstorage/index.phps
@@ -34,7 +34,7 @@
  * is stored in browser localStorage, so there's nothing real-world
  * about this.
  */
-require_once('../../src/u2flib_server/U2F.php');
+require_once __DIR__ . '/../../vendor/autoload.php';
 $scheme = isset($_SERVER['HTTPS']) ? "https://" : "http://";
 $u2f = new u2flib_server\U2F($scheme . $_SERVER['HTTP_HOST']);
 ?>

--- a/examples/pdo/index.phps
+++ b/examples/pdo/index.phps
@@ -33,7 +33,7 @@
  * registrations. It supports multiple registrations associated with each user.
  */
 
-require_once('../../src/u2flib_server/U2F.php');
+require_once __DIR__ . '/../../vendor/autoload.php';
 
 $dbfile = '/var/tmp/u2f-pdo.sqlite';
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,4 +6,9 @@
     <logging>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/u2flib_server/Error.php
+++ b/src/u2flib_server/Error.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace u2flib_server;
+
+/**
+ * Error class, returned on errors
+ */
+class Error extends \Exception
+{
+    /**
+     * Override constructor and make message and code mandatory.
+     * @param string $message
+     * @param int $code
+     * @param \Exception|null $previous
+     */
+    public function __construct($message, $code, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/u2flib_server/RegisterRequest.php
+++ b/src/u2flib_server/RegisterRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace u2flib_server;
+
+/**
+ * Class for building a registration request.
+ */
+class RegisterRequest
+{
+    /** Protocol version */
+    public $version = U2F_VERSION;
+
+    /** Registration challenge */
+    public $challenge;
+
+    /** Application id */
+    public $appId;
+
+    /**
+     * @param string $challenge
+     * @param string $appId
+     */
+    public function __construct($challenge, $appId)
+    {
+        $this->challenge = $challenge;
+        $this->appId = $appId;
+    }
+}

--- a/src/u2flib_server/Registration.php
+++ b/src/u2flib_server/Registration.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace u2flib_server;
+
+/**
+ * Class returned for successful registrations.
+ */
+class Registration
+{
+    /** The key handle of the registered authenticator. */
+    public $keyHandle;
+
+    /** The public key of the registered authenticator. */
+    public $publicKey;
+
+    /** The attestation certificate of the registered authenticator. */
+    public $certificate;
+
+    /** The counter associated with this registration. */
+    public $counter = -1;
+}

--- a/src/u2flib_server/SignRequest.php
+++ b/src/u2flib_server/SignRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace u2flib_server;
+
+/**
+ * Class for building up an authentication request.
+ */
+class SignRequest
+{
+    /** Protocol version. */
+    public $version = U2F_VERSION;
+
+    /** Authentication challenge. */
+    public $challenge;
+
+    /** Key handle of a registered authenticator */
+    public $keyHandle;
+
+    /** Application id */
+    public $appId;
+}

--- a/src/u2flib_server/U2F.php
+++ b/src/u2flib_server/U2F.php
@@ -238,7 +238,7 @@ class U2F
     }
 
     /**
-     * Called to verify an authentication response
+     * Called to verify an authentication response.
      *
      * @param array $requests An array of outstanding authentication requests
      * @param array $registrations An array of current registrations
@@ -341,6 +341,19 @@ class U2F
     }
 
     /**
+     * Retrieves the challenge from a raw response.
+     * @param object $response A response from the authenticator
+     * @return mixed the decoded client data
+     */
+    public function extractChallenge($response)
+    {
+        $clientData = $this->base64u_decode($response->clientData);
+        $cli = json_decode($clientData);
+
+        return $cli->challenge;
+    }
+
+    /**
      * @param string $data
      * @return string
      */
@@ -390,10 +403,13 @@ class U2F
     }
 
     /**
-     * @return string
-     * @throws Error
+     * called to create a challenge. For testing purposes, the U2F class can be inherited,
+     * and this method overridden to always return the same challenge.
+     *
+     * @return string the challenge
+     * @throws Error if openssl doesn't have cryptographically strong source
      */
-    private function createChallenge()
+    protected function createChallenge()
     {
         $challenge = openssl_random_pseudo_bytes(32, $crypto_strong );
         if( $crypto_strong !== true ) {
@@ -417,91 +433,5 @@ class U2F
             $cert[strlen($cert) - 257] = "\0";
         }
         return $cert;
-    }
-}
-
-/**
- * Class for building a registration request
- *
- * @package u2flib_server
- */
-class RegisterRequest
-{
-    /** Protocol version */
-    public $version = U2F_VERSION;
-
-    /** Registration challenge */
-    public $challenge;
-
-    /** Application id */
-    public $appId;
-
-    /**
-     * @param string $challenge
-     * @param string $appId
-     * @internal
-     */
-    public function __construct($challenge, $appId)
-    {
-        $this->challenge = $challenge;
-        $this->appId = $appId;
-    }
-}
-
-/**
- * Class for building up an authentication request
- *
- * @package u2flib_server
- */
-class SignRequest
-{
-    /** Protocol version */
-    public $version = U2F_VERSION;
-
-    /** Authentication challenge */
-    public $challenge;
-
-    /** Key handle of a registered authenticator */
-    public $keyHandle;
-
-    /** Application id */
-    public $appId;
-}
-
-/**
- * Class returned for successful registrations
- *
- * @package u2flib_server
- */
-class Registration
-{
-    /** The key handle of the registered authenticator */
-    public $keyHandle;
-
-    /** The public key of the registered authenticator */
-    public $publicKey;
-
-    /** The attestation certificate of the registered authenticator */
-    public $certificate;
-
-    /** The counter associated with this registration */
-    public $counter = -1;
-}
-
-/**
- * Error class, returned on errors
- *
- * @package u2flib_server
- */
-class Error extends \Exception
-{
-    /**
-     * Override constructor and make message and code mandatory
-     * @param string $message
-     * @param int $code
-     * @param \Exception|null $previous
-     */
-    public function __construct($message, $code, \Exception $previous = null) {
-        parent::__construct($message, $code, $previous);
     }
 }

--- a/tests/u2flib_test.php
+++ b/tests/u2flib_test.php
@@ -28,7 +28,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-require_once(__DIR__ . '/../src/u2flib_server/U2F.php');
+require_once __DIR__ . '/../vendor/autoload.php';
 
 class U2FTest extends \PHPUnit_Framework_TestCase {
   /** @var u2flib_server\U2F */
@@ -66,7 +66,7 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
-   * @expectedException u2flib_server\Error
+   * @expectedException \u2flib_server\Error
    * @expectedExceptionCode u2flib_server\ERR_ATTESTATION_VERIFICATION
    */
   public function testDoRegisterAttestFail() {
@@ -77,7 +77,7 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
-   * @expectedException u2flib_server\Error
+   * @expectedException \u2flib_server\Error
    * @expectedExceptionCode u2flib_server\ERR_ATTESTATION_SIGNATURE
    */
   public function testDoRegisterFail2() {
@@ -87,7 +87,7 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
-   * @expectedException u2flib_server\Error
+   * @expectedException \u2flib_server\Error
    * @expectedExceptionCode u2flib_server\ERR_UNMATCHED_CHALLENGE
    */
   public function testDoRegisterFail() {
@@ -107,7 +107,7 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
-   * @expectedException u2flib_server\Error
+   * @expectedException \u2flib_server\Error
    * @expectedExceptionCode u2flib_server\ERR_PUBKEY_DECODE
    */
   public function testDoRegisterBadKeyInCert() {
@@ -117,7 +117,7 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
-   * @expectedException u2flib_server\Error
+   * @expectedException \u2flib_server\Error
    * @expectedExceptionCode u2flib_server\ERR_PUBKEY_DECODE
    */
   public function testDoRegisterBadKey() {
@@ -147,7 +147,7 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
-   * @expectedException u2flib_server\Error
+   * @expectedException \u2flib_server\Error
    * @expectedExceptionCode u2flib_server\ERR_BAD_UA_RETURNING
    */
   public function testDoRegisterUAError() {
@@ -194,7 +194,7 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
-   * @expectedException u2flib_server\Error
+   * @expectedException \u2flib_server\Error
    * @expectedExceptionCode u2flib_server\ERR_COUNTER_TOO_LOW
    */
   public function testDoAuthenticateCtrFail() {
@@ -205,7 +205,7 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
-   * @expectedException u2flib_server\Error
+   * @expectedException \u2flib_server\Error
    * @expectedExceptionCode u2flib_server\ERR_AUTHENTICATION_FAILURE
    */
   public function testDoAuthenticateFail() {
@@ -216,7 +216,7 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
-   * @expectedException u2flib_server\Error
+   * @expectedException \u2flib_server\Error
    * @expectedExceptionCode u2flib_server\ERR_NO_MATCHING_REQUEST
    */
   public function testDoAuthenticateWrongReq() {
@@ -227,7 +227,7 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
-   * @expectedException u2flib_server\Error
+   * @expectedException \u2flib_server\Error
    * @expectedExceptionCode u2flib_server\ERR_NO_MATCHING_REGISTRATION
    */
   public function testDoAuthenticateWrongReg() {
@@ -238,7 +238,7 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
-   * @expectedException u2flib_server\Error
+   * @expectedException \u2flib_server\Error
    * @expectedExceptionCode u2flib_server\ERR_PUBKEY_DECODE
    */
   public function testDoAuthenticateBadKey() {
@@ -282,7 +282,7 @@ class U2FTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
-   * @expectedException u2flib_server\Error
+   * @expectedException \u2flib_server\Error
    * @expectedExceptionCode u2flib_server\ERR_BAD_UA_RETURNING
    */
   public function testDoAuthenticateUAError() {


### PR DESCRIPTION
This makes it easier to write test cases for U2F implementation: you are able to mock the server and use testvectors to log in.

Furthermore, the classes have been split into several files. Issue #2 should not be a problem anymore, as this should be fixed here: https://github.com/composer/composer/pull/4907 if I'm correct.