### PR TITLE
Improve U2F::createChallenge reliability

### DIFF
--- a/src/u2flib_server/U2F.php
+++ b/src/u2flib_server/U2F.php
@@ -396,7 +396,7 @@ class U2F
     private function createChallenge()
     {
         $challenge = openssl_random_pseudo_bytes(32, $crypto_strong );
-        if( $crypto_strong !== true ) {
+        if($crypto_strong !== true || $challenge === false) {
             throw new Error('Unable to obtain a good source of randomness', ERR_BAD_RANDOM);
         }
 


### PR DESCRIPTION
By also testing the outcome of the openssl_random_pseudo_bytes which is
caught in the `$challenge` variable. We can prevent a possible
unexpected error down the line.

Admittedly a minor improvement, but it could prove useful someday.

See https://github.com/Yubico/php-u2flib-server/issues/65